### PR TITLE
SteamVR Eye Tracking Support for OpenXR

### DIFF
--- a/projects/psvr2_openvr_driver_ex/hmd2_gaze.h
+++ b/projects/psvr2_openvr_driver_ex/hmd2_gaze.h
@@ -35,6 +35,30 @@ typedef struct {
   Hmd2Bool blink;
 } Hmd2GazeEye;
 
+struct Hmd2GazeCombined {
+    Hmd2Bool isGazeOriginValid;
+    Hmd2Vector3 gazeOriginMm;
+
+    Hmd2Bool isGazeDirValid;
+    Hmd2Vector3 gazeDirNorm;
+
+    Hmd2Bool isValid;
+    uint32_t timestamp;
+
+    Hmd2Bool unk06;
+    float unk07;
+
+    Hmd2Bool unk08;
+
+    // All gazes seem to be repeated here?
+    // No obvious differences here.
+    Hmd2Vector3 leftGazeDirNormal;
+    Hmd2Vector3 rightGazeDirNormal;
+    Hmd2Vector3 combinedGazeDirNormal;
+
+    float unk09;
+};
+
 struct Hmd2GazeState {
   char magic[2];
   uint16_t version;
@@ -75,6 +99,5 @@ struct Hmd2GazeState {
 
   Hmd2GazeEye leftEye;
   Hmd2GazeEye rightEye;
-
-  uint32_t unk26[23]; // Likely combined gaze?
+  Hmd2GazeCombined combined;
 };

--- a/projects/psvr2_openvr_driver_ex/hmd_device_hooks.cpp
+++ b/projects/psvr2_openvr_driver_ex/hmd_device_hooks.cpp
@@ -93,19 +93,19 @@ namespace psvr2_toolkit {
   void HmdDeviceHooks::UpdateGaze(void* pData, size_t dwSize)
   {
       Hmd2GazeState* pGazeState = reinterpret_cast<Hmd2GazeState*>(pData);
-      vr::VREyeTrackingData_t et {};
+      vr::VREyeTrackingData_t eyeTrackingData {};
 
       bool valid = pGazeState->combined.isGazeDirValid;
 
-      et.bActive = valid;
-      et.bTracked = valid;
-      et.bValid = valid;
+      eyeTrackingData.bActive = valid;
+      eyeTrackingData.bTracked = valid;
+      eyeTrackingData.bValid = valid;
 
       auto& origin = pGazeState->combined.gazeOriginMm;
       auto& direction = pGazeState->combined.gazeDirNorm;
 
-      et.vGazeOrigin = vr::HmdVector3_t { -origin.x / 1000.0f, origin.y / 1000.0f, -origin.z / 1000.0f };
-      et.vGazeTarget = vr::HmdVector3_t { -direction.x, direction.y, -direction.z };
+      eyeTrackingData.vGazeOrigin = vr::HmdVector3_t { -origin.x / 1000.0f, origin.y / 1000.0f, -origin.z / 1000.0f };
+      eyeTrackingData.vGazeTarget = vr::HmdVector3_t { -direction.x, direction.y, -direction.z };
 
       int64_t hmdToHostOffset;
 
@@ -113,7 +113,7 @@ namespace psvr2_toolkit {
 
       double timeOffset = ((static_cast<int64_t>(pGazeState->combined.timestamp) + hmdToHostOffset) - GetHostTimestamp()) / 1e6;
 
-      (vr::VRDriverInput())->UpdateEyeTrackingComponent(eyeTrackingComponent, &et, timeOffset);
+      (vr::VRDriverInput())->UpdateEyeTrackingComponent(eyeTrackingComponent, &eyeTrackingData, timeOffset);
 
 #ifdef OPENVR_EXTENSIONS_AVAILABLE
     if (g_pOpenVRExHandle) {

--- a/projects/psvr2_openvr_driver_ex/hmd_device_hooks.cpp
+++ b/projects/psvr2_openvr_driver_ex/hmd_device_hooks.cpp
@@ -2,6 +2,8 @@
 #include "psvr2_openvr_driver/openvr_ex/openvr_ex.h"
 #endif
 
+#include "hmd2_gaze.h"
+
 #include "hmd_device_hooks.h"
 
 #include "hmd_driver_loader.h"
@@ -16,6 +18,7 @@ namespace psvr2_toolkit {
 #ifdef OPENVR_EXTENSIONS_AVAILABLE
   void* g_pOpenVRExHandle = nullptr;
 #endif
+  vr::VRInputComponentHandle_t eyeTrackingComponent;
 
   vr::EVRInitError (*sie__psvr2__HmdDevice__Activate)(void *, uint32_t) = nullptr;
   vr::EVRInitError sie__psvr2__HmdDevice__ActivateHook(void *thisptr, uint32_t unObjectId) {
@@ -37,6 +40,20 @@ namespace psvr2_toolkit {
     // Tell SteamVR our dashboard scale.
     vr::VRProperties()->SetFloatProperty(ulPropertyContainer, vr::Prop_DashboardScale_Float, .9f);
 
+    vr::VRProperties()->SetBoolProperty(ulPropertyContainer, vr::Prop_SupportsXrEyeGazeInteraction_Bool, true);
+
+    if (vr::VRDriverInput())
+    {
+        vr::EVRInputError result = (vr::VRDriverInput())->CreateEyeTrackingComponent(ulPropertyContainer, "/eyetracking", &eyeTrackingComponent);
+        if (result != vr::VRInputError_None) {
+            vr::VRDriverLog()->Log("Failed to create eye tracking component.");
+        }
+    }
+    else
+    {
+        vr::VRDriverLog()->Log("Failed to get driver input interface. Are you on the latest version of SteamVR?");
+    }
+
 #ifdef OPENVR_EXTENSIONS_AVAILABLE
     psvr2_toolkit::openvr_ex::OnHmdActivate(ulPropertyContainer, &g_pOpenVRExHandle);
 #endif
@@ -55,8 +72,49 @@ namespace psvr2_toolkit {
 #endif
   }
 
+  void* (*CaesarManager__getInstance)();
+  uint64_t(*CaesarManager__getIMUTimestampOffset)(void* thisptr, int64_t* hmdToHostOffset);
+
+  inline const int64_t GetHostTimestamp()
+  {
+      static LARGE_INTEGER frequency{};
+      if (frequency.QuadPart == 0)
+      {
+          QueryPerformanceFrequency(&frequency);
+      }
+
+      LARGE_INTEGER now;
+      QueryPerformanceCounter(&now);
+
+      return static_cast<int64_t>((static_cast<double>(now.QuadPart) /
+          static_cast<double>(frequency.QuadPart)) * 1e6);
+  }
+
   void HmdDeviceHooks::UpdateGaze(void* pData, size_t dwSize)
   {
+      Hmd2GazeState* pGazeState = reinterpret_cast<Hmd2GazeState*>(pData);
+      vr::VREyeTrackingData_t et {};
+
+      bool valid = pGazeState->combined.isGazeDirValid;
+
+      et.bActive = valid;
+      et.bTracked = valid;
+      et.bValid = valid;
+
+      auto& origin = pGazeState->combined.gazeOriginMm;
+      auto& direction = pGazeState->combined.gazeDirNorm;
+
+      et.vGazeOrigin = vr::HmdVector3_t { -origin.x / 1000.0f, origin.y / 1000.0f, -origin.z / 1000.0f };
+      et.vGazeTarget = vr::HmdVector3_t { -direction.x, direction.y, -direction.z };
+
+      int64_t hmdToHostOffset;
+
+      CaesarManager__getIMUTimestampOffset(CaesarManager__getInstance(), &hmdToHostOffset);
+
+      double timeOffset = ((static_cast<int64_t>(pGazeState->combined.timestamp) + hmdToHostOffset) - GetHostTimestamp()) / 1e6;
+
+      (vr::VRDriverInput())->UpdateEyeTrackingComponent(eyeTrackingComponent, &et, timeOffset);
+
 #ifdef OPENVR_EXTENSIONS_AVAILABLE
     if (g_pOpenVRExHandle) {
       psvr2_toolkit::openvr_ex::OnHmdUpdate(&g_pOpenVRExHandle, pData, dwSize);
@@ -76,6 +134,9 @@ namespace psvr2_toolkit {
     HookLib::InstallHook(reinterpret_cast<void *>(pHmdDriverLoader->GetBaseAddress() + 0x19EBF0),
                          reinterpret_cast<void *>(sie__psvr2__HmdDevice__DeactivateHook),
                          reinterpret_cast<void **>(&sie__psvr2__HmdDevice__Deactivate));
+
+    CaesarManager__getInstance = decltype(CaesarManager__getInstance)(pHmdDriverLoader->GetBaseAddress() + 0x124c90);
+    CaesarManager__getIMUTimestampOffset = decltype(CaesarManager__getIMUTimestampOffset)(pHmdDriverLoader->GetBaseAddress() + 0x1252e0);
   }
 
 } // psvr2_toolkit

--- a/projects/psvr2_openvr_driver_ex/psvr2_openvr_driver/openvr/headers/openvr_driver.h
+++ b/projects/psvr2_openvr_driver_ex/psvr2_openvr_driver/openvr/headers/openvr_driver.h
@@ -16,8 +16,8 @@
 namespace vr
 {
 	static const uint32_t k_nSteamVRVersionMajor = 2;
-	static const uint32_t k_nSteamVRVersionMinor = 5;
-	static const uint32_t k_nSteamVRVersionBuild = 1;
+	static const uint32_t k_nSteamVRVersionMinor = 12;
+	static const uint32_t k_nSteamVRVersionBuild = 14;
 } // namespace vr
 
 // public_vrtypes.h
@@ -104,6 +104,16 @@ struct VRBoneTransform_t
 	HmdQuaternionf_t orientation;
 };
 
+struct VREyeTrackingData_t
+{
+	bool bActive;
+	bool bValid;
+	bool bTracked;
+
+	vr::HmdVector3_t vGazeOrigin;  // Ray origin
+	vr::HmdVector3_t vGazeTarget;  // Gaze target (fixation point)
+};
+
 /** Used to return the post-distortion UVs for each color channel.
 * UVs range from 0 to 1 with 0,0 in the upper left corner of the
 * source render target. The 0,0 to 1,1 range covers a single eye. */
@@ -135,6 +145,7 @@ enum ETextureType
 							// eye texture (vr::EVREye::Eye_Right)
 
 	TextureType_Reserved = 7,
+	TextureType_SharedTextureHandle = 8, // A pointer to a vr::SharedTextureHandle_t that was imported via, eg. ImportDmabuf.
 };
 
 enum EColorSpace
@@ -191,6 +202,32 @@ typedef double vrshared_double __attribute__ ((aligned(8)));
 typedef uint64_t vrshared_uint64_t;
 typedef double vrshared_double;
 #endif
+
+static const uint32_t MaxDmabufPlaneCount = 4;
+
+struct DmabufPlane_t
+{
+	uint32_t unOffset;
+	uint32_t unStride;
+	int32_t nFd;
+};
+
+struct DmabufAttributes_t
+{
+	void *pNext; // MUST be NULL. Unused right now, but could be used to extend this structure in the future.
+
+	uint32_t unWidth;
+	uint32_t unHeight;
+	uint32_t unDepth;
+	uint32_t unMipLevels;
+	uint32_t unArrayLayers;
+	uint32_t unSampleCount;
+	uint32_t unFormat;   // DRM_FORMAT_
+	uint64_t ulModifier; // DRM_FORMAT_MOD_
+
+	uint32_t unPlaneCount;
+	DmabufPlane_t plane[MaxDmabufPlaneCount];
+};
 
 #pragma pack( pop )
 
@@ -435,6 +472,10 @@ enum ETrackedDeviceProperty
 	Prop_DevicePowerUsage_Float					= 1052,
 	Prop_IgnoreMotionForStandby_Bool			= 1053,
 	Prop_ActualTrackingSystemName_String		= 1054, // the literal local driver name in case someone is playing games with prop 1000
+	Prop_AllowCameraToggle_Bool					= 1055, // Shows the Enable/Disable camera option. Hide this for certain headsets if they have the camera tracking (since it's always on)
+	Prop_AllowLightSourceFrequency_Bool			= 1056, // Shows the Anti-Flicker option in camera settings.
+	Prop_SteamRemoteClientID_Uint64				= 1057, // For vrlink
+	Prop_Reserved_1058							= 1058,
 
 	// Properties that are unique to TrackedDeviceClass_HMD
 	Prop_ReportsTimeSinceVSync_Bool				= 2000,
@@ -527,11 +568,13 @@ enum ETrackedDeviceProperty
     Prop_CameraGlobalGain_Float                 = 2089,
 	// Prop_DashboardLayoutPathName_String 		= 2090, // DELETED
 	Prop_DashboardScale_Float 					= 2091,
-	Prop_PeerButtonInfo_String					= 2092,
+	// Prop_PeerButtonInfo_String					= 2092, // DELETED
 	Prop_Hmd_SupportsHDR10_Bool					= 2093,
 	Prop_Hmd_EnableParallelRenderCameras_Bool	= 2094,
 	Prop_DriverProvidedChaperoneJson_String		= 2095, // higher priority than Prop_DriverProvidedChaperonePath_String
 	Prop_ForceSystemLayerUseAppPoses_Bool		= 2096,
+	Prop_DashboardLinkSupport_Int32				= 2097,
+	Prop_DisplayMinUIAnalogGain_Float 			= 2098,
 
 	Prop_IpdUIRangeMinMeters_Float 				= 2100,
 	Prop_IpdUIRangeMaxMeters_Float 				= 2101,
@@ -542,15 +585,17 @@ enum ETrackedDeviceProperty
 	Prop_Hmd_SupportsAppThrottling_Bool			= 2106,
 	Prop_Hmd_SupportsGpuBusMonitoring_Bool		= 2107,
 	Prop_DriverDisplaysIPDChanges_Bool			= 2108,
-	Prop_Driver_Reserved_01						= 2109,
-
-	Prop_DSCVersion_Int32						= 2110,
-	Prop_DSCSliceCount_Int32					= 2111,
-	Prop_DSCBPPx16_Int32						= 2112,
+	// Prop_Driver_RecenterSupport_Int32			= 2109, // DELETED
+	Prop_Reserved_2110							= 2110,
+	Prop_Reserved_2111							= 2111,
+	Prop_Reserved_2112							= 2112,
 
 	Prop_Hmd_MaxDistortedTextureWidth_Int32		= 2113,
 	Prop_Hmd_MaxDistortedTextureHeight_Int32	= 2114,
 	Prop_Hmd_AllowSupersampleFiltering_Bool		= 2115,
+
+	Prop_Hmd_AllowsClientToControlTextureIndex  = 2116,
+	Prop_Reserved_2117							= 2117,
 
 	// Driver requested mura correction properties
 	Prop_DriverRequestedMuraCorrectionMode_Int32		= 2200,
@@ -573,6 +618,10 @@ enum ETrackedDeviceProperty
 	Prop_Audio_DriverManagesRecordingVolumeControl_Bool		= 2307,
 	Prop_Audio_DriverRecordingVolume_Float					= 2308,
 	Prop_Audio_DriverRecordingMute_Bool						= 2309,
+
+	// Pipewire Audio Stuff
+	Prop_Audio_PipewirePlaybackNode_Int32					= 2400,
+	Prop_Audio_PipewireRecordingNode_Int32					= 2401,
 
 	// Properties that are unique to TrackedDeviceClass_Controller
 	Prop_AttachedDeviceId_String				= 3000,
@@ -623,6 +672,9 @@ enum ETrackedDeviceProperty
 	Prop_HasVirtualDisplayComponent_Bool		= 6006,
 	Prop_HasSpatialAnchorsSupport_Bool			= 6007,
 	Prop_SupportsXrTextureSets_Bool				= 6008,
+	Prop_SupportsXrEyeGazeInteraction_Bool		= 6009,
+	Prop_DeviceHasNoIMU_Bool					= 6010,
+	Prop_UseAdvancedPrediction_Bool				= 6011,
 
 	// Properties that are set internally based on other information provided by drivers
 	Prop_ControllerType_String					= 7000,
@@ -632,6 +684,13 @@ enum ETrackedDeviceProperty
 	// Vendors are free to expose private debug data in this reserved region
 	Prop_VendorSpecific_Reserved_Start			= 10000,
 	Prop_VendorSpecific_Reserved_End			= 10999,
+
+	// Addl SteamVR Reserved Space
+	Prop_Reserved_11000							= 11000,
+	Prop_Reserved_11001							= 11001,
+	Prop_Reserved_11002							= 11002,
+	Prop_Reserved_11003							= 11003,
+	Prop_Reserved_11004							= 11004,
 
 	Prop_TrackedDeviceProperty_Max				= 1000000,
 };
@@ -673,10 +732,12 @@ enum EHmdTrackingStyle
 typedef uint64_t VRActionHandle_t;
 typedef uint64_t VRActionSetHandle_t;
 typedef uint64_t VRInputValueHandle_t;
+typedef uint64_t VRInputComponentHandle_t;
 
 static const VRActionHandle_t k_ulInvalidActionHandle = 0;
 static const VRActionSetHandle_t k_ulInvalidActionSetHandle = 0;
 static const VRInputValueHandle_t k_ulInvalidInputValueHandle = 0;
+static const VRInputComponentHandle_t k_ulInvalidInputComponentHandle = 0;
 
 
 /** Allows the application to control how scene textures are used by the compositor when calling Submit. */
@@ -706,7 +767,7 @@ enum EVRSubmitFlags
 
 	// Set to indicate a discontinuity between this and the last frame.
 	// This will prevent motion smoothing from attempting to extrapolate using the pair.
-	Submit_FrameDiscontinuty = 0x20,
+	Submit_FrameDiscontinuity = 0x20,
 
 	// Set to indicate that pTexture->handle is a contains VRVulkanTextureArrayData_t
 	Submit_VulkanTextureWithArrayData = 0x40,
@@ -720,7 +781,8 @@ enum EVRSubmitFlags
 	// Do not use
 	Submit_Reserved2 = 0x08000,
 	Submit_Reserved3 = 0x10000,
-
+	Submit_Reserved4 = 0x20000,
+	Submit_Reserved5 = 0x40000,
 };
 
 /** Data required for passing Vulkan textures to IVRCompositor::Submit.
@@ -788,8 +850,8 @@ enum EVREventType
 	VREvent_PropertyChanged				= 111,
 	VREvent_WirelessDisconnect			= 112,
 	VREvent_WirelessReconnect			= 113,
-	VREvent_Reserved_01					= 114,
-	VREvent_Reserved_02					= 115,
+	VREvent_Reserved_0114				= 114,
+	VREvent_Reserved_0115				= 115,
 
 	VREvent_ButtonPress					= 200, // data is controller
 	VREvent_ButtonUnpress				= 201, // data is controller
@@ -844,7 +906,7 @@ enum EVREventType
 	VREvent_DashboardActivated			= 502,
 	VREvent_DashboardDeactivated		= 503,
 	//VREvent_DashboardThumbSelected		= 504, // Sent to the overlay manager - data is overlay - No longer sent
-	VREvent_DashboardRequested			= 505, // Sent to the overlay manager - data is overlay
+	//VREvent_DashboardRequested			= 505, // Sent to the overlay manager - data is overlay
 	VREvent_ResetDashboard				= 506, // Send to the overlay manager
 	//VREvent_RenderToast					= 507, // Send to the dashboard to render a toast - data is the notification ID -- no longer sent
 	VREvent_ImageLoaded					= 508, // Sent to overlays when a SetOverlayRaw or SetOverlayFromFile call finishes loading
@@ -877,18 +939,22 @@ enum EVREventType
 
 	VREvent_StartDashboard					= 532,
 	VREvent_ElevatePrism					= 533,
-
 	VREvent_OverlayClosed					= 534,
-
 	VREvent_DashboardThumbChanged			= 535, // Sent when a dashboard thumbnail image changes
-
 	VREvent_DesktopMightBeVisible			= 536, // Sent when any known desktop related overlay is visible
 	VREvent_DesktopMightBeHidden			= 537, // Sent when all known desktop related overlays are hidden
-
 	VREvent_MutualSteamCapabilitiesChanged	= 538, // Sent when the set of capabilities common between both Steam and SteamVR have changed.
-
 	VREvent_OverlayCreated					= 539, // An OpenVR overlay of any sort was created. Data is overlay.
 	VREvent_OverlayDestroyed				= 540, // An OpenVR overlay of any sort was destroyed. Data is overlay.
+
+	VREvent_TrackingRecordingStarted		= 541,
+	VREvent_TrackingRecordingStopped		= 542,
+	VREvent_SetTrackingRecordingPath		= 543,
+
+	VREvent_Reserved_0560  					= 560, // No data
+	VREvent_Reserved_0561  					= 561, // No data
+	VREvent_Reserved_0562					= 562, // No data
+	VREvent_Reserved_0563					= 563, // No data
 
 	VREvent_Notification_Shown				= 600,
 	VREvent_Notification_Hidden				= 601,
@@ -902,6 +968,7 @@ enum EVREventType
 	VREvent_DriverRequestedQuit				= 704, // The driver has requested that SteamVR shut down
 	VREvent_RestartRequested				= 705, // A driver or other component wants the user to restart SteamVR
 	VREvent_InvalidateSwapTextureSets		= 706,
+	VREvent_RequestDisconnectWirelessHMD	= 707, // vrserver asks vrlink to disconnect
 
 	VREvent_ChaperoneDataHasChanged			= 800, // this will never happen with the new chaperone system
 	VREvent_ChaperoneUniverseHasChanged		= 801,
@@ -910,8 +977,11 @@ enum EVREventType
 	VREvent_SeatedZeroPoseReset				= 804,
 	VREvent_ChaperoneFlushCache				= 805, // Sent when the process needs to reload any cached data it retrieved from VRChaperone()
 	VREvent_ChaperoneRoomSetupStarting	    = 806, // Triggered by CVRChaperoneClient::RoomSetupStarting
-	VREvent_ChaperoneRoomSetupFinished	    = 807, // Triggered by CVRChaperoneClient::CommitWorkingCopy
+	VREvent_ChaperoneRoomSetupCommitted	    = 807, // Triggered by CVRChaperoneClient::CommitWorkingCopy (formerly VREvent_ChaperoneRoomSetupFinished)
 	VREvent_StandingZeroPoseReset			= 808,
+	VREvent_Reserved_0809  					= 809,
+	VREvent_Reserved_0810  					= 810,
+	VREvent_Reserved_0811  					= 811,
 
 	VREvent_AudioSettingsHaveChanged		= 820,
 
@@ -949,8 +1019,8 @@ enum EVREventType
 	VREvent_FirmwareUpdateFinished			= 1101,
 
 	VREvent_KeyboardClosed					= 1200, // DEPRECATED: Sent only to the overlay it closed for, or globally if it was closed for a scene app
-	VREvent_KeyboardCharInput				= 1201,
-	VREvent_KeyboardDone					= 1202, // Sent when DONE button clicked on keyboard
+	VREvent_KeyboardCharInput				= 1201, // Sent on keyboard input. Warning: event type appears as both global event and overlay event
+	VREvent_KeyboardDone					= 1202, // Sent when DONE button clicked on keyboard. Warning: event type appears as both global event and overlay event
 	VREvent_KeyboardOpened_Global			= 1203, // Sent globally when the keyboard is opened. data.keyboard.overlayHandle is who it was opened for (scene app if k_ulOverlayHandleInvalid)
 	VREvent_KeyboardClosed_Global			= 1204, // Sent globally when the keyboard is closed. data.keyboard.overlayHandle is who it was opened for (scene app if k_ulOverlayHandleInvalid)
 
@@ -1014,6 +1084,8 @@ enum EVREventType
 	VREvent_Audio_SetSpeakersMute			= 2101,
 	VREvent_Audio_SetMicrophoneVolume		= 2102,
 	VREvent_Audio_SetMicrophoneMute			= 2103,
+
+	VREvent_RenderModel_CountChanged       = 2200, //Number of RenderModels in the system has changed
 
 	// Vendors are free to expose private events in this reserved region
 	VREvent_VendorSpecific_Reserved_Start	= 10000,
@@ -2316,7 +2388,9 @@ VR_CAMERA_DECL_ALIGN( 8 ) struct CameraVideoStreamFrame_t
 
 // ivrsettings.h
 
+#ifndef OPENVR_NO_STL
 #include <string>
+#endif
 
 namespace vr
 {
@@ -2389,10 +2463,12 @@ namespace vr
 		{
 			m_pSettings->SetString( pchSection, pchSettingsKey, pchValue, peError );
 		}
+#ifndef OPENVR_NO_STL
 		void SetString( const std::string & sSection, const std::string &  sSettingsKey, const std::string & sValue, EVRSettingsError *peError = nullptr )
 		{
 			m_pSettings->SetString( sSection.c_str(), sSettingsKey.c_str(), sValue.c_str(), peError );
 		}
+#endif
 
 		bool GetBool( const char *pchSection, const char *pchSettingsKey, EVRSettingsError *peError = nullptr )
 		{
@@ -2410,6 +2486,7 @@ namespace vr
 		{
 			m_pSettings->GetString( pchSection, pchSettingsKey, pchValue, unValueLen, peError );
 		}
+#ifndef OPENVR_NO_STL
 		std::string GetString( const std::string & sSection, const std::string & sSettingsKey, EVRSettingsError *peError = nullptr )
 		{
 			char buf[4096];
@@ -2422,6 +2499,7 @@ namespace vr
 			else
 				return "";
 		}
+#endif
 
 		void RemoveSection( const char *pchSection, EVRSettingsError *peError = nullptr )
 		{
@@ -2470,6 +2548,10 @@ namespace vr
 	static const char * const k_pch_SteamVR_AdditionalFramesToPredict_Int32 = "additionalFramesToPredict";
 	static const char * const k_pch_SteamVR_WorldScale_Float = "worldScale";
 	static const char * const k_pch_SteamVR_FovScale_Int32 = "fovScale";
+	static const char * const k_pch_SteamVR_FovScaleInner_Int32 = "fovScaleInner";
+	static const char * const k_pch_SteamVR_FovScaleUpper_Int32 = "fovScaleUpper";
+	static const char * const k_pch_SteamVR_FovScaleLower_Int32 = "fovScaleLower";
+	static const char * const k_pch_SteamVR_FovScaleFormat_Int32 = "fovScaleFormat";
 	static const char * const k_pch_SteamVR_FovScaleLetterboxed_Bool = "fovScaleLetterboxed";
 	static const char * const k_pch_SteamVR_DisableAsyncReprojection_Bool = "disableAsync";
 	static const char * const k_pch_SteamVR_ForceFadeOnBadTracking_Bool = "forceFadeOnBadTracking";
@@ -2494,7 +2576,6 @@ namespace vr
 	static const char * const k_pch_SteamVR_EnableLinuxVulkanAsync_Bool = "enableLinuxVulkanAsync";
 	static const char * const k_pch_SteamVR_AllowDisplayLockedMode_Bool = "allowDisplayLockedMode";
 	static const char * const k_pch_SteamVR_HaveStartedTutorialForNativeChaperoneDriver_Bool = "haveStartedTutorialForNativeChaperoneDriver";
-	static const char * const k_pch_SteamVR_ForceWindows32bitVRMonitor = "forceWindows32BitVRMonitor";
 	static const char * const k_pch_SteamVR_DebugInputBinding = "debugInputBinding";
 	static const char * const k_pch_SteamVR_DoNotFadeToGrid = "doNotFadeToGrid";
 	static const char * const k_pch_SteamVR_EnableSharedResourceJournaling = "enableSharedResourceJournaling";
@@ -2516,6 +2597,7 @@ namespace vr
 	static const char * const k_pch_SteamVR_DisplayPortTrainingMode_Int = "displayPortTrainingMode";
 	static const char * const k_pch_SteamVR_UsePrism_Bool = "usePrism";
 	static const char * const k_pch_SteamVR_AllowFallbackMirrorWindowLinux_Bool = "allowFallbackMirrorWindowLinux";
+	static const char * const k_pch_SteamVR_DisableKeyboardPrivacy_Bool = "disableKeyboardPrivacy";
 
 	//-----------------------------------------------------------------------------
 	// openxr keys
@@ -2571,6 +2653,8 @@ namespace vr
 	static const char * const k_pch_UserInterface_HidePopupsWhenStatusMinimized_Bool = "HidePopupsWhenStatusMinimized";
 	static const char * const k_pch_UserInterface_Screenshots_Bool = "screenshots";
 	static const char * const k_pch_UserInterface_ScreenshotType_Int = "screenshotType";
+	static const char * const k_pch_UserInterface_CheckStatusInterval_Int = "vrmStatusCheckInterval";
+	static const char * const k_pch_UserInterface_CheckForSteam_Bool = "vrmCheckForSteam";
 
 	//-----------------------------------------------------------------------------
 	// notification keys
@@ -2668,11 +2752,11 @@ namespace vr
 	static const char * const k_pch_Dashboard_DesktopScale = "desktopScale";
 	static const char * const k_pch_Dashboard_DashboardScale = "dashboardScale";
 	static const char * const k_pch_Dashboard_UseStandaloneSystemLayer = "standaloneSystemLayer";
-	static const char * const k_pch_Dashboard_StickyDashboard = "stickyDashboard";
 	static const char * const k_pch_Dashboard_AllowSteamOverlays_Bool = "allowSteamOverlays";
 	static const char * const k_pch_Dashboard_AllowVRGamepadUI_Bool = "allowVRGamepadUI";
 	static const char * const k_pch_Dashboard_AllowVRGamepadUIViaGamescope_Bool = "allowVRGamepadUIViaGamescope";
 	static const char * const k_pch_Dashboard_SteamMatchesHMDFramerate = "steamMatchesHMDFramerate";
+	static const char * const k_pch_Dashboard_GrabHandleAcceleration = "grabHandleAcceleration";
 
 	//-----------------------------------------------------------------------------
 	// model skin keys
@@ -2683,6 +2767,8 @@ namespace vr
 	static const char * const k_pch_Driver_Enable_Bool = "enable";
 	static const char * const k_pch_Driver_BlockedBySafemode_Bool = "blocked_by_safe_mode";
 	static const char * const k_pch_Driver_LoadPriority_Int32 = "loadPriority";
+	static const char * const k_pch_Driver_Hmd_AllowsClientToControlTextureIndex_Bool = "hmdAllowsClientToControlTextureIndex";
+	static const char * const k_pch_Driver_ForceSystemLayerUseAppPoses_Bool = "forceSystemLayerUseAppPoses";
 
 	//-----------------------------------------------------------------------------
 	// web interface keys
@@ -2725,6 +2811,8 @@ namespace vr
 	static const char* const k_pch_LastKnown_HMDManufacturer_String = "HMDManufacturer";
 	static const char *const k_pch_LastKnown_HMDModel_String = "HMDModel";
 	static const char* const k_pch_LastKnown_ActualHMDDriver_String = "ActualHMDDriver";
+	static const char* const k_pch_LastKnown_HMDSerialNumber_String = "HMDSerialNumber";
+	static const char* const k_pch_LastKnown_HMDRemoteClientID_String = "RemoteClientID"; // uint64 in string
 
 	//-----------------------------------------------------------------------------
 	// Dismissed warnings
@@ -2740,6 +2828,10 @@ namespace vr
 	//-----------------------------------------------------------------------------
 	// Log of GPU performance
 	static const char * const k_pch_GpuSpeed_Section = "GpuSpeed";
+
+	//-----------------------------------------------------------------------------
+	// OpenXR Render Model Extension keys
+	static const char *const k_pch_XRRenderModelCache_Section = "XRRenderModelUuidCache";
 
 } // namespace vr
 
@@ -2855,9 +2947,7 @@ public:
 	* exceed the length of the supplied buffer should be truncated and null terminated */
 	virtual void DebugRequest( const char *pchRequest, char *pchResponseBuffer, uint32_t unResponseBufferSize ) = 0;
 
-	// ------------------------------------
-	// Tracking Methods
-	// ------------------------------------
+	/** This interface is unused, and will never be called. */
 	virtual DriverPose_t GetPose() = 0;
 };
 
@@ -3685,10 +3775,6 @@ inline bool CVRPropertyHelpers::IsPropertySet( PropertyContainerHandle_t ulConta
 
 namespace vr
 {
-
-	typedef uint64_t VRInputComponentHandle_t;
-	static const VRInputComponentHandle_t k_ulInvalidInputComponentHandle = 0;
-
 	enum EVRScalarType
 	{
 		VRScalarType_Absolute = 0,
@@ -3727,9 +3813,20 @@ namespace vr
 		/** Updates a skeleton component. */
 		virtual EVRInputError UpdateSkeletonComponent( VRInputComponentHandle_t ulComponent, EVRSkeletalMotionRange eMotionRange, const VRBoneTransform_t *pTransforms, uint32_t unTransformCount ) = 0;
 
+		/** Creates a pose component */
+		virtual EVRInputError CreatePoseComponent( PropertyContainerHandle_t ulContainer, const char *pchName, VRInputComponentHandle_t *pHandle ) = 0;
+
+		/** Updates a pose component. */
+		virtual EVRInputError UpdatePoseComponent( VRInputComponentHandle_t ulComponent, const HmdMatrix34_t *pMatPoseOffset, double fTimeOffset ) = 0;
+
+		/** Creates an eye tracking component **/
+		virtual EVRInputError CreateEyeTrackingComponent( PropertyContainerHandle_t ulContainer, const char *pchName, VRInputComponentHandle_t *pHandle ) = 0;
+
+		/** Updates an eye tracking component. */
+		virtual EVRInputError UpdateEyeTrackingComponent( VRInputComponentHandle_t ulComponent, const VREyeTrackingData_t *pEyeTrackingData, double fTimeOffset ) = 0;
 	};
 
-	static const char * const IVRDriverInput_Version = "IVRDriverInput_003";
+	static const char * const IVRDriverInput_Version = "IVRDriverInput_004";
 
 } // namespace vr
 
@@ -4162,10 +4259,10 @@ public:
 	virtual bool NewSharedVulkanImage( uint32_t nImageFormat, uint32_t nWidth, uint32_t nHeight, bool bRenderable, bool bMappable, bool bComputeAccess, uint32_t unMipLevels, uint32_t unArrayLayerCount, vr::SharedTextureHandle_t *pSharedHandle ) = 0;
 
 	/** Create a new tracked Vulkan Buffer */
-	virtual bool NewSharedVulkanBuffer( size_t nSize, uint32_t nUsageFlags, vr::SharedTextureHandle_t *pSharedHandle ) = 0;
+	virtual bool NewSharedVulkanBuffer( uint32_t nSize, uint32_t nUsageFlags, vr::SharedTextureHandle_t *pSharedHandle ) = 0;
 
 	/** Create a new tracked Vulkan Semaphore */
-	virtual bool NewSharedVulkanSemaphore( vr::SharedTextureHandle_t *pSharedHandle ) = 0;
+	virtual bool NewSharedVulkanSemaphore( bool bCounting, vr::SharedTextureHandle_t *pSharedHandle ) = 0;
 
 	/** Grab a reference to hSharedHandle, and optionally generate a new IPC handle if pNewIpcHandle is not nullptr  */
 	virtual bool RefResource( vr::SharedTextureHandle_t hSharedHandle, uint64_t *pNewIpcHandle ) = 0;
@@ -4173,12 +4270,51 @@ public:
 	/** Drop a reference to hSharedHandle */
 	virtual bool UnrefResource( vr::SharedTextureHandle_t hSharedHandle ) = 0;
 
+	/* Get all the DRM formats we support using DMA-BUF images for.
+	 *
+	 * pOutFormatCount and pOutFormats function like Vulkan:
+	 *   - If pOutFormats is NULL, then pOutFormatCount will be overwritten with the format count.
+	 *   - If pOutFormats is not NULL, then pOutFormatCount specifies the size of the pOutFormats array,
+	 *       and will be overwritten with the number of formats written to the array.
+	 *
+	 * If the function fails, false is returned, and pOutFormatCount will be 0.
+	 * Supported on Linux only.
+	 */
+	virtual bool GetDmabufFormats( uint32_t *pOutFormatCount, uint32_t *pOutFormats ) = 0;
+
+	/** Get dmabuf modifiers we are allowed to use.
+	 *
+	 * pOutModifierCount and pOutModifiers function like Vulkan:
+	 *   - If pOutModifiers is NULL, then pOutModifierCount will be overwritten with the modifier count.
+	 *   - If pOutModifiers is not NULL, then pOutModifierCount specifies the size of the pOutModifiers array,
+	 *       and will be overwritten with the number of modifiers written to the array.
+	 *
+	 * If modifiers are not supported, a single DRM_FORMAT_MOD_INVALID entry will be returned.
+	 *
+	 * If the function fails, false is returned, and pOutModifierCount will be 0.
+	 * Supported on Linux only.
+	 */
+	virtual bool GetDmabufModifiers( vr::EVRApplicationType eApplicationType, uint32_t unDRMFormat, uint32_t *pOutModifierCount, uint64_t *pOutModifiers ) = 0;
+
+	/** Import a dmabuf directly.
+	 * Note: the FD you pass in will be dup'ed, so you must close it yourself.
+	 * This function does NOT take ownership of the fd you pass in.
+	 * Supported on Linux only.
+	 */
+	virtual bool ImportDmabuf( vr::EVRApplicationType eApplicationType, vr::DmabufAttributes_t *pDmabufAttributes, vr::SharedTextureHandle_t *pSharedHandle ) = 0;
+
+	/** Consumes an IPC handle (eg. from RefResource) and returns a file-descriptor.
+	 * Caller acquires ownership of fd and is responsible for closing it.
+	 * Supported on Linux only.
+	 */
+	virtual bool ReceiveSharedFd( uint64_t ulIpcHandle, int *pOutFd ) = 0;
+
 protected:
 	/** Non-deletable */
 	virtual ~IVRIPCResourceManagerClient() {};
 };
 
-static const char *IVRIPCResourceManagerClient_Version = "IVRIPCResourceManagerClient_001";
+static const char *IVRIPCResourceManagerClient_Version = "IVRIPCResourceManagerClient_002";
 
 }
 


### PR DESCRIPTION
## Changes
- Update OpenVR SDK to 2.12.14
- Add combined gaze struct
- Add SteamVR eye tracking component and provide combined gaze data from `HmdDeviceHooks::UpdateGaze`
    - This also attempts to use the timestamp in the eye tracking data to provide an accurate time offset to `UpdateEyeTrackingComponent`.

![Recording 2025-09-11 221616](https://github.com/user-attachments/assets/43508391-3012-4eef-906b-bae2c697bd74)
