### PR TITLE
Upload build artifacts, add workflow_dispatch trigger

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -48,7 +48,7 @@ jobs:
       run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} /p:OutDir=${{env.ARTIFACTS_DIR}} ${{env.SOLUTION_FILE_PATH}}
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: psvr2-toolkit-build
         path: ${{env.ARTIFACTS_DIR}}

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -10,6 +10,7 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  workflow_dispatch:
 
 env:
   # Path to the solution file relative to the root of the project.
@@ -19,6 +20,9 @@ env:
   # You can convert this to a build matrix if you need coverage of multiple configuration types.
   # https://docs.github.com/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
   BUILD_CONFIGURATION: ReleaseCI
+
+  # Directory for build artifacts
+  ARTIFACTS_DIR: artifacts
 
 permissions:
   contents: read
@@ -41,4 +45,10 @@ jobs:
       working-directory: ${{env.GITHUB_WORKSPACE}}
       # Add additional options to the MSBuild command line here (like platform or verbosity level).
       # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
-      run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} ${{env.SOLUTION_FILE_PATH}}
+      run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} /p:OutDir=${{env.ARTIFACTS_DIR}} ${{env.SOLUTION_FILE_PATH}}
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: psvr2-toolkit-build
+        path: ${{env.ARTIFACTS_DIR}}

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -22,7 +22,7 @@ env:
   BUILD_CONFIGURATION: ReleaseCI
 
   # Directory for build artifacts
-  ARTIFACTS_DIR: artifacts
+  ARTIFACTS_DIR: ${{github.workspace}}/artifacts
 
 permissions:
   contents: read


### PR DESCRIPTION
## Changes
- Upload output artifacts with action
- Add `workflow_dispatch` to allow making builds for any branch
    - The motivation behind this is to allow me (and anybody else with permissions) to build branches without needing to make a PR for them.