### PR TITLE
Pass all arguments through to CaesarManager::initialize to avoid register stomping crash

### DIFF
--- a/projects/psvr2_openvr_driver_ex/caesar_manager_hooks.cpp
+++ b/projects/psvr2_openvr_driver_ex/caesar_manager_hooks.cpp
@@ -10,12 +10,12 @@ namespace psvr2_toolkit {
 
   void *(*Framework__Thread__start)(void *thisptr) = nullptr;
 
-  void* (*CaesarManager__initialize)(void*, void*, void*) = nullptr;
-  void* CaesarManager__initializeHook(void* thisptr, void* arg1, void* arg2) {
+  void *(*CaesarManager__initialize)(void *, void *, void *) = nullptr;
+  void *CaesarManager__initializeHook(void *thisptr, void *arg1, void *arg2) {
     static CaesarUsbThreadGaze* pCaesarUsbThreadGaze = CaesarUsbThreadGaze::Instance();
 
     void* result = CaesarManager__initialize(thisptr, arg1, arg2);
-    (*(void(__fastcall**)(__int64, __int64))(*(__int64*)pCaesarUsbThreadGaze + 24LL))((__int64)pCaesarUsbThreadGaze, 0);
+    (*(void (__fastcall **)(__int64, __int64))(*(__int64 *)pCaesarUsbThreadGaze + 24LL))((__int64)pCaesarUsbThreadGaze, 0);
     Framework__Thread__start(pCaesarUsbThreadGaze);
     return result;
   }

--- a/projects/psvr2_openvr_driver_ex/caesar_manager_hooks.cpp
+++ b/projects/psvr2_openvr_driver_ex/caesar_manager_hooks.cpp
@@ -10,12 +10,12 @@ namespace psvr2_toolkit {
 
   void *(*Framework__Thread__start)(void *thisptr) = nullptr;
 
-  void *(*CaesarManager__initialize)(void *) = nullptr;
-  void *CaesarManager__initializeHook(void *thisptr) {
-    static CaesarUsbThreadGaze *pCaesarUsbThreadGaze = CaesarUsbThreadGaze::Instance();
+  void* (*CaesarManager__initialize)(void*, void*, void*) = nullptr;
+  void* CaesarManager__initializeHook(void* thisptr, void* arg1, void* arg2) {
+    static CaesarUsbThreadGaze* pCaesarUsbThreadGaze = CaesarUsbThreadGaze::Instance();
 
-    void* result = CaesarManager__initialize(thisptr);
-    (*(void (__fastcall **)(__int64, __int64))(*(__int64 *)pCaesarUsbThreadGaze + 24LL))((__int64)pCaesarUsbThreadGaze, 0);
+    void* result = CaesarManager__initialize(thisptr, arg1, arg2);
+    (*(void(__fastcall**)(__int64, __int64))(*(__int64*)pCaesarUsbThreadGaze + 24LL))((__int64)pCaesarUsbThreadGaze, 0);
     Framework__Thread__start(pCaesarUsbThreadGaze);
     return result;
   }


### PR DESCRIPTION
Thanks to `mjcox24` in the Discord, we were able to hunt down an issue where the driver could crash in `CaesarManager::initialize` due to a stomped register when `Activate` is called twice by SteamVR in some cases.