### PR TITLE
Update build runner to windows-2025-vs2026

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: windows-2025-vs2026
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
This fixes the CI failures that we have had for months due to no Github runner image with VS 2026.