### PR TITLE
Improve the alternative name fallback system for the HMD driver loader

### DIFF
--- a/projects/psvr2_openvr_driver_ex/hmd_driver_loader.cpp
+++ b/projects/psvr2_openvr_driver_ex/hmd_driver_loader.cpp
@@ -3,8 +3,6 @@
 #include <shlwapi.h>
 
 #define HMD_DLL_NAME L"driver_playstation_vr2_orig.dll"
-// Just in case people fuck up renaming a file, somehow.
-#define HMD_DLL_NAME_ALT L"driver_playstation_vr2_orig.dll.dll"
 
 extern "C" IMAGE_DOS_HEADER __ImageBase;
 
@@ -26,8 +24,8 @@ namespace psvr2_toolkit {
     , m_hModule(nullptr)
   {
     // Attempt to load the HMD DLL with the default name.
-    // If we can't, try the alternative name.
-    if (!LoadHmdDll()) {
+    // If we can't, try to find an alternative fallback name.
+    if (!LoadHmdDll(false)) {
       LoadHmdDll(true);
     }
   }
@@ -66,8 +64,40 @@ namespace psvr2_toolkit {
     DWORD dwLength = GetModuleFileNameW(reinterpret_cast<HINSTANCE>(&__ImageBase), pszPath, MAX_PATH);
     if (dwLength > 0 && dwLength < MAX_PATH) {
       if (PathRemoveFileSpecW(pszPath)) {
-        if (PathCombineW(pszHmdDllPath, pszPath, !useAltName ? HMD_DLL_NAME : HMD_DLL_NAME_ALT)) {
-          return true;
+        if (!useAltName) {
+          // Normal load behavior using exact standard name
+          if (PathCombineW(pszHmdDllPath, pszPath, HMD_DLL_NAME)) {
+            return true;
+          }
+        } else {
+          // Fallback search behavior
+          wchar_t searchPattern[MAX_PATH] = {0};
+          if (PathCombineW(searchPattern, pszPath, L"driver_playstation_vr2*.dll")) {
+            WIN32_FIND_DATAW findData;
+            HANDLE hFind = FindFirstFileW(searchPattern, &findData);
+            if (hFind != INVALID_HANDLE_VALUE) {
+              do {
+                if (findData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
+                  continue;
+                }
+
+                // Ignore the PSVR2TK driver first to avoid conflicts.
+                if (StrCmpIW(findData.cFileName, L"driver_playstation_vr2.dll") == 0) {
+                  continue;
+                }
+
+                // Look for a file starting with "driver_playstation_vr2" (22 characters to compare)
+                if (StrCmpNIW(findData.cFileName, L"driver_playstation_vr2", 22) == 0) {
+                  
+                  if (PathCombineW(pszHmdDllPath, pszPath, findData.cFileName)) {
+                    FindClose(hFind);
+                    return true;
+                  }
+                }
+              } while (FindNextFileW(hFind, &findData));
+              FindClose(hFind);
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
My change makes PSVR2TK's HMD driver loader search for the original driver if its name begins with "driver_playstation_vr2" and uses it. I made sure Toolkit does not target itself when searching.
The search will only happen if the original driver isn't named correctly.